### PR TITLE
ci: Fix release job is not triggered on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: pull_request
+on:
+  pull_request: {}
+  push:
+    tags: ['v*']
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
       - run: ./gradlew assemble
       - uses: actions/upload-artifact@v4
         with:
@@ -36,8 +34,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
       - run: ./gradlew assemble
       - name: Create Release
         id: create_release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,15 +9,15 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'
       - name: Make gradlew executable
         run: chmod +x ./gradlew
       - run: ./gradlew assemble
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: '**/*.apk'
       - uses: yumemi-inc/comment-pull-request@v1
@@ -31,8 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'


### PR DESCRIPTION
The release job was introduced in https://github.com/unlimish/x2vx-android/commit/f45dc80377262b9602b59b80623f479166d3d705 but it's not working as 'push' trigger on tags is not set up. This pull request adds a 'push' trigger on 'v*' tags, improving the workflow slightly.